### PR TITLE
Implement sold out badge and disable Add  button

### DIFF
--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,15 +1,26 @@
 <article>
   <%= link_to product_path(product) do %>
-    <%= image_tag product.image.thumb.url , alt: product.name %>
+    <%= image_tag product.image.thumb.url, alt: product.name %>
     <h1>
+    
       <span><%= product.name %></span>
+      
       <span><%= humanized_money_with_symbol product.price %></span>
     </h1>
-  <% end%>
+    
+  <% end %>
+
+
   <div>
-    <%= button_to add_item_cart_path(product_id: product.id), class: 'btn' ,
-    method: :post do %>
-      <%= fa_icon "shopping-cart", text: 'Add' %> 
+    <% if product.quantity <= 0 %>
+  <span class="soldout">Sold Out</span>
+<% end %>
+    <%= button_to add_item_cart_path(product_id: product.id), class: "btn" + (product.quantity <= 0 ? " disabled" : ""),
+                                                              method: :post do %>
+    
+      <%= fa_icon "shopping-cart", text: "Add" %> 
+      
     <% end %>
+
   </div>
 </article>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -213,7 +213,7 @@ cat3.products.create!({
   As a defense mechanism the Cliff Collard grows thick thorns.
   They rely on winds to carry their seeds away to reproduce. Once pollinated, they grow small, inedible fruits.",
   image: open_asset('plante_12.jpg'),
-  quantity: 23,
+  quantity: 0,
   price: 79.99
 })
 


### PR DESCRIPTION
implement a feature that displays a "Sold Out" badge on products with a quantity of 0 and disable the "Add item" button for these products. This helps users to easily identify which products are out of stock on the product list page

